### PR TITLE
Lazy conversion of sequences in hybrid->clojure

### DIFF
--- a/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
+++ b/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
@@ -58,7 +58,7 @@
   (-> value (OperationUtil/getBytes) thaw))
 
 (defmethod hybrid->clojure ISeq [^ISeq value]
-  (mapv hybrid->clojure value))
+  (map hybrid->clojure value))
 
 ;; ******* Serialization ********
 (defn ^:private cs-freeze [value]


### PR DESCRIPTION
Think this is causing the memory issue. Confirming in a test run.
All tests in pigpen-cascading still pass.
